### PR TITLE
unbound requires 2 runs to initialise

### DIFF
--- a/site-modules/profile/manifests/app/keepalived.pp
+++ b/site-modules/profile/manifests/app/keepalived.pp
@@ -69,7 +69,4 @@ class profile::app::keepalived (
     }
   }
 
-# unbound setup
-  contain profile::app::unbound
-
 }

--- a/site-modules/profile/manifests/app/keepalived.pp
+++ b/site-modules/profile/manifests/app/keepalived.pp
@@ -70,6 +70,6 @@ class profile::app::keepalived (
   }
 
 # unbound setup
-  include profile::app::unbound
+  contain profile::app::unbound
 
 }

--- a/site-modules/profile/manifests/app/unbound.pp
+++ b/site-modules/profile/manifests/app/unbound.pp
@@ -44,6 +44,7 @@ class profile::app::unbound (
       # Use local DNS servers for local domain
       unbound::stub { $trusted['domain']:
         address => lookup('defaults::dns::nameservers'),
+        require => Class['unbound'],
       }
       # Enable unbound-resolvconf service
       # TODO check whether this is needed
@@ -58,13 +59,15 @@ class profile::app::unbound (
       }
       $interface_list = $interfaces
 
+      service { 'unbound-resolvconf': enable => false, status => stopped, }
       # Just ship to systemd-resolved
       unbound::forward { '.':
         address => [ '127.0.0.53' ],
+        require => Class['unbound'],
       }
     }
   }
-  -> class { 'unbound':
+  class { 'unbound':
     interface              => $interface_list,
     interface_automatic    => false,
     access                 => [ "${lookup('defaults::cidr')}", '127.0.0.0/8' ],

--- a/site-modules/profile/manifests/app/unbound.pp
+++ b/site-modules/profile/manifests/app/unbound.pp
@@ -23,6 +23,7 @@ class profile::app::unbound (
   file { '/etc/apparmor.d/local/usr.sbin.unbound':
     ensure  => file,
     notify  => Service['unbound', 'apparmor'],
+    require => Class['unbound'],
     content => @("EOT"),
                capability net_raw,
                | EOT

--- a/site-modules/profile/manifests/app/unbound.pp
+++ b/site-modules/profile/manifests/app/unbound.pp
@@ -64,6 +64,10 @@ class profile::app::unbound (
       $purge_unbound_conf_d = true
     }
   }
+
+# TODO for some reason not all of the config is applied on the first run
+# TODO in particular ip_transparent is not set causing unbound service start to fail
+# TODO work out why this is the case!
   class { 'unbound':
     interface              => $interface_list,
     interface_automatic    => false,

--- a/site-modules/profile/manifests/app/unbound.pp
+++ b/site-modules/profile/manifests/app/unbound.pp
@@ -23,6 +23,7 @@ class profile::app::unbound (
   file { '/etc/apparmor.d/local/usr.sbin.unbound':
     ensure  => file,
     notify  => Service['apparmor'],
+    require  => Class['unbound'],
     content => @("EOT"),
                capability net_raw,
                | EOT
@@ -76,6 +77,7 @@ class profile::app::unbound (
     purge_unbound_conf_d   => false,
     ip_transparent         => true,
     require                => Service['systemd-resolved'],
+    before                 => File[ '/etc/apparmor.d/local/usr.sbin.unbound' ],
   }
   class { 'unbound::remote': enable => true, }
 

--- a/site-modules/profile/manifests/app/unbound.pp
+++ b/site-modules/profile/manifests/app/unbound.pp
@@ -18,16 +18,7 @@ class profile::app::unbound (
     unit   => 'unbound.service',
   }
 
-# Add net_raw to allow ip_transparent to work
   include profile::platform::baseline::debian::apparmor
-  file { '/etc/apparmor.d/local/usr.sbin.unbound':
-    ensure  => file,
-    notify  => Service['unbound', 'apparmor'],
-    require => Class['unbound'],
-    content => @("EOT"),
-               capability net_raw,
-               | EOT
-  }
 
 # These interfaces are common
   $interfaces = [ $gateway, $facts['networking']['interfaces'][$lan]['ip'] ]
@@ -77,6 +68,14 @@ class profile::app::unbound (
     purge_unbound_conf_d   => false,
     ip_transparent         => true,
     require                => Service['systemd-resolved'],
+  }
+# Add net_raw to allow ip_transparent to work
+  -> file { '/etc/apparmor.d/local/usr.sbin.unbound':
+    ensure  => file,
+    notify  => Service['unbound', 'apparmor'],
+    content => @("EOT"),
+               capability net_raw,
+               | EOT
   }
   class { 'unbound::remote': enable => true, }
 

--- a/site-modules/profile/manifests/app/unbound.pp
+++ b/site-modules/profile/manifests/app/unbound.pp
@@ -18,7 +18,15 @@ class profile::app::unbound (
     unit   => 'unbound.service',
   }
 
+# Add net_raw to allow ip_transparent to work
   include profile::platform::baseline::debian::apparmor
+  file { '/etc/apparmor.d/local/usr.sbin.unbound':
+    ensure  => file,
+    notify  => Service['apparmor'],
+    content => @("EOT"),
+               capability net_raw,
+               | EOT
+  }
 
 # These interfaces are common
   $interfaces = [ $gateway, $facts['networking']['interfaces'][$lan]['ip'] ]
@@ -68,14 +76,6 @@ class profile::app::unbound (
     purge_unbound_conf_d   => false,
     ip_transparent         => true,
     require                => Service['systemd-resolved'],
-  }
-# Add net_raw to allow ip_transparent to work
-  -> file { '/etc/apparmor.d/local/usr.sbin.unbound':
-    ensure  => file,
-    notify  => Service['unbound', 'apparmor'],
-    content => @("EOT"),
-               capability net_raw,
-               | EOT
   }
   class { 'unbound::remote': enable => true, }
 

--- a/site-modules/profile/manifests/app/unbound.pp
+++ b/site-modules/profile/manifests/app/unbound.pp
@@ -55,7 +55,7 @@ class profile::app::unbound (
       }
       $interface_list = $interfaces
 
-      #service { 'unbound-resolvconf': enable => false, status => stopped, }
+      service { 'unbound-resolvconf': enable => false, status => stopped, }
       # Just ship to systemd-resolved
       unbound::forward { '.':
         address => [ '127.0.0.53' ],

--- a/site-modules/profile/manifests/app/unbound.pp
+++ b/site-modules/profile/manifests/app/unbound.pp
@@ -23,7 +23,7 @@ class profile::app::unbound (
   file { '/etc/apparmor.d/local/usr.sbin.unbound':
     ensure  => file,
     notify  => Service['apparmor'],
-    require  => Class['unbound'],
+    before  => Service['unbound'],
     content => @("EOT"),
                capability net_raw,
                | EOT
@@ -76,9 +76,8 @@ class profile::app::unbound (
     val_permissive_mode    => true,
     purge_unbound_conf_d   => false,
     ip_transparent         => true,
-    require                => Service['systemd-resolved'],
-    before                 => File[ '/etc/apparmor.d/local/usr.sbin.unbound' ],
+    require                => [ Service['systemd-resolved'], File[ '/etc/apparmor.d/local/usr.sbin.unbound' ], ],
   }
-  class { 'unbound::remote': enable => true, }
+  -> class { 'unbound::remote': enable => true, }
 
 }


### PR DESCRIPTION
For some unknown reason in the first run ip_transparent is not set causing the daemon start to fail. this PR tries to fix the dependencies and start order but has not been successful. almost all other settings are applied (interface, etc) as per the manifest but not ip_transparent.